### PR TITLE
Use the dotnet-nightly alpine image to make a smaller forwarder

### DIFF
--- a/app-insight-local-forwarder/Dockerfile
+++ b/app-insight-local-forwarder/Dockerfile
@@ -1,5 +1,6 @@
-FROM microsoft/dotnet:2.1-runtime
+FROM microsoft/dotnet-nightly:2.2-runtime-alpine3.8
 
+RUN apk --no-cache add libc6-compat
 RUN mkdir /lf
 ADD . /lf/
 WORKDIR /lf/bin


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This PR makes the local forwarder for App Insight Live Metrics smaller by using the dotnet-nightly alpine image (with libc6-compat installed)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

