### PR TITLE
Remove probes from counter

### DIFF
--- a/charts/online-store/templates/counter-deployment.yaml
+++ b/charts/online-store/templates/counter-deployment.yaml
@@ -23,14 +23,6 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 8080
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 8080
           imagePullPolicy: {{ .Values.counter.image.pullPolicy }}
           env:
             - name: NAMESPACE


### PR DESCRIPTION
When the counter lands on VK with private networking, the health checks are bad. 